### PR TITLE
Adding Debian Support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,16 +30,28 @@ It also optionaly manages the contents of the Kerberos client configuration and 
 ### What realmd affects
 
 * Packages
-    * realmd
-    * adcli
-    * sssd
-    * krb5-workstation
-    * oddjob
-    * oddjob-mkhomedir
+    * Redhat Family
+        * realmd
+        * adcli
+        * sssd
+        * krb5-workstation
+        * oddjob
+        * oddjob-mkhomedir
+    * Debian Family
+        * adcli
+        * krb5-user
+        * sssd
+        * sssd-tools
+        * samba-common-bin
+        * samba
+        * libpam-modules
+        * libpam-sss
+        * libnss-sss
 * Files
     * /etc/realmd.conf
     * /etc/sssd/sssd.conf
     * /etc/krb5.conf
+    * /usr/share/pam-configs/realmd_mkhomedir (Debian Family)
 * Services
     * sssd
 * Execs
@@ -49,6 +61,8 @@ It also optionaly manages the contents of the Kerberos client configuration and 
         * the kerberos config file (/etc/krb5.conf) will be placed on disk
         * the `kinit` command is run to obtain an initial TGT
         * the `realm join` command is run to join via keytab
+    * For Debian Family
+        * triggers a pam-auth-update to activate the mkhomedir
 
 ### Setup Requirements
 
@@ -134,5 +148,4 @@ Default values are in params.pp.
 
 ## Limitations
 
-This module requires Puppet >= 3.4.0 or Puppet Enterprise >= 3.2 due to it's use of the `contain` function. It has only been tested on RHEL/CentOS 7.
-
+This module requires Puppet >= 3.4.0 or Puppet Enterprise >= 3.2 due to it's use of the `contain` function. It has only been tested on RHEL/CentOS 7 and Debian Jessie 8

--- a/files/realmd_mkhomedir
+++ b/files/realmd_mkhomedir
@@ -1,0 +1,6 @@
+Name: Make home directory for new logins
+Default: yes
+Priority: 900
+Session-Type: Additional
+Session:
+        required                        pam_mkhomedir.so umask=0022 skel=/etc/skel

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,4 +15,21 @@ class realmd::config {
     content => template('realmd/realmd.conf.erb'),
   }
 
+  if $::osfamily == "Debian" {
+    file { '/usr/share/pam-configs/realmd_mkhomedir':
+      ensure => file,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+      source => 'puppet:///modules/realmd/realmd_mkhomedir',
+      notify => Exec['realm-pam-auth-update'],
+    }
+
+    exec { 'realm-pam-auth-update':
+      command     => '/usr/sbin/pam-auth-update --package',
+      refreshonly => true,
+    }
+
+  }
+
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,7 @@ class realmd::config {
     content => template('realmd/realmd.conf.erb'),
   }
 
-  if $::osfamily == "Debian" {
+  if $::osfamily == 'Debian' {
     file { '/usr/share/pam-configs/realmd_mkhomedir':
       ensure => file,
       owner  => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,44 @@ class realmd::params {
       }
       $manage_krb_config       = true
     }
+    'Debian': {
+      $realmd_package_name     = 'realmd'
+      $realmd_config_file      = '/etc/realmd.conf'
+      $realmd_config           = {}
+      $adcli_package_name      = 'adcli'
+      $krb_client_package_name = 'krb5-user'
+      $sssd_package_name       = 'sssd'
+      $sssd_service_name       = 'sssd'
+      $sssd_config_file        = '/etc/sssd/sssd.conf'
+      $sssd_config             = {}
+      $manage_sssd_config      = false
+      $mkhomedir_package_names = [
+        'samba-common-bin',
+        'libpam-modules',
+        'libpam-sss',
+        'sssd-tools',
+        'libnss-sss',
+        'samba',
+      ]
+      $domain                  = $::domain
+      $domain_join_user        = undef
+      $domain_join_password    = undef
+      $krb_ticket_join         = false
+      $krb_keytab              = undef
+      $krb_config_file         = '/etc/krb5.conf'
+      $krb_config              = {
+        'logging' => {
+          'default' => 'FILE:/var/log/krb5libs.log',
+        },
+        'libdefaults' => {
+          'default_realm'    => upcase($::domain),
+          'dns_lookup_realm' => true,
+          'dns_lookup_kdc'   => true,
+          'kdc_timesync'     => '0',
+        },
+      }
+      $manage_krb_config       = true
+    }
     default: {
       fail("${::operatingsystem} not supported")
     }


### PR DESCRIPTION
My machine was not able to run the unit tests due to an error; however, I ran `puppet apply` on the code below and it successfully joined a domain and created a home directory upon login on Debian Jessie 8. I am estimating travis-ci will run the tests with this pull request and they will pass. If not, I will fix.

```
  class { '::realmd':
      domain             => $::domain,
      domain_join_user   => 'user',
     domain_join_password => 'password',
      krb_ticket_join    => false,
      manage_sssd_config => true,
      sssd_config        => {
        'sssd' => {
          'domains'             => $::domain,
          'config_file_version' => '2',
          'services'            => 'nss,pam',
        },
        "domain/${::domain}" => {
          'ad_domain'                      => $::domain,
          'krb5_realm'                     => upcase($::domain),
          'realmd_tags'                    => 'manages-system joined-with-adcli',
          'cache_credentials'              => 'True',
          'id_provider'                    => 'ad',
          'access_provider'                => 'ad',
          'krb5_store_password_if_offline' => 'True',
          'default_shell'                  => '/bin/bash',
          'ldap_id_mapping'                => 'True',
          'fallback_homedir'               => '/home/%u',
        },
      },
    }
```
