### PR TITLE
klist lists the host with a maximum of 15 characters.

### DIFF
--- a/manifests/join/keytab.pp
+++ b/manifests/join/keytab.pp
@@ -42,7 +42,7 @@ class realmd::join::keytab {
   exec { 'realm_join_with_keytab':
     path    => '/usr/bin:/usr/sbin:/bin',
     command => "realm join ${_domain}",
-    unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname}@${_domain}'",
+    unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
     require => Exec['run_kinit_with_keytab'],
   }
 

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -12,7 +12,7 @@ class realmd::join::password {
   exec { 'realm_join_with_password':
     path    => '/usr/bin:/usr/sbin:/bin',
     command => "echo '${_password}' | realm join ${_domain} --unattended --user=${_user}",
-    unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname}@${_domain}'",
+    unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
   }
 
 }


### PR DESCRIPTION
This allows the hostname to be truncated in the same manner as it is stored in the krb5.keytab file. Fixes issue #7.
