### PR TITLE
For rm commands, supply path instead of hardcoding one location

### DIFF
--- a/manifests/sssd/config.pp
+++ b/manifests/sssd/config.pp
@@ -16,7 +16,8 @@ class realmd::sssd::config {
     }
 
     exec { 'force_config_cache_rebuild':
-      command     => "/usr/bin/rm -f ${::realmd::sssd_config_cache_file}",
+      path        => '/usr/bin:/usr/sbin:/bin',
+      command     => "rm -f ${::realmd::sssd_config_cache_file}",
       refreshonly => true,
     }
   }

--- a/spec/classes/sssd__config_spec.rb
+++ b/spec/classes/sssd__config_spec.rb
@@ -44,7 +44,6 @@ describe 'realmd' do
 
           it do
             should contain_exec('force_config_cache_rebuild').with({
-            	
               'path'        => '/usr/bin:/usr/sbin:/bin',
               'command'     => 'rm -f /var/lib/sss/db/config.ldb',
               'refreshonly' => true,

--- a/spec/classes/sssd__config_spec.rb
+++ b/spec/classes/sssd__config_spec.rb
@@ -44,7 +44,9 @@ describe 'realmd' do
 
           it do
             should contain_exec('force_config_cache_rebuild').with({
-              'command'     => '/usr/bin/rm -f /var/lib/sss/db/config.ldb',
+            	
+              'path'        => '/usr/bin:/usr/sbin:/bin',
+              'command'     => 'rm -f /var/lib/sss/db/config.ldb',
               'refreshonly' => true,
             })
           end


### PR DESCRIPTION
The _command_ variable inside the exec resource in the files:

```
manifests/sssd/config.pp
spec/classes/sssd__config_spec.rb
```

uses the full location for rm (_/usr/bin/rm_). This is a problem for Debian/Ubuntu systems, where _rm_ is only located in _/bin_.

This patch changes this setting, so that a path is supplied (the same as in _manifests/join/keytab.pp_).
