### PR TITLE
Fix kinit never being run

### DIFF
--- a/manifests/join/keytab.pp
+++ b/manifests/join/keytab.pp
@@ -17,7 +17,7 @@ class realmd::join::keytab {
     owner  => 'root',
     group  => 'root',
     mode   => '0400',
-    before => Exec['run_kinit_with_keytab'],
+    notify => Exec['run_kinit_with_keytab'],
   }
 
   if $_manage_krb_config {
@@ -28,7 +28,7 @@ class realmd::join::keytab {
       group   => 'root',
       mode    => '0644',
       content => template('realmd/krb5.conf.erb'),
-      before  => Exec['run_kinit_with_keytab'],
+      notify  => Exec['run_kinit_with_keytab'],
     }
   }
 

--- a/spec/classes/join__keytab_spec.rb
+++ b/spec/classes/join__keytab_spec.rb
@@ -28,7 +28,7 @@ describe 'realmd' do
               'owner' => 'root',
               'group' => 'root',
               'mode'  => '0400',
-            }).that_comes_before('Exec[run_kinit_with_keytab]')
+            }).that_notifies('Exec[run_kinit_with_keytab]')
           end
 
           it do
@@ -37,7 +37,7 @@ describe 'realmd' do
               'owner' => 'root',
               'group' => 'root',
               'mode'  => '0644',
-            }).that_comes_before('Exec[run_kinit_with_keytab]')
+            }).that_notifies('Exec[run_kinit_with_keytab]')
           end
 
           it do


### PR DESCRIPTION
The exec run_kinit_with_keytab never executed, because it only was called using "before" (but "refreshonly" is set to true). With notify now a refresh is triggered when the resource(s) change.
