### PR TITLE
Added samba common tools package as required for CENTOS 7 use

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,26 +11,27 @@
 #   e.g. "Specify one or more upstream ntp servers as an array."
 #
 class realmd (
-  $realmd_package_name     = $::realmd::params::realmd_package_name,
-  $realmd_config_file      = $::realmd::params::realmd_config_file,
-  $realmd_config           = $::realmd::params::realmd_config,
-  $adcli_package_name      = $::realmd::params::adcli_package_name,
-  $krb_client_package_name = $::realmd::params::krb_client_package_name,
-  $sssd_package_name       = $::realmd::params::sssd_package_name,
-  $sssd_service_name       = $::realmd::params::sssd_service_name,
-  $sssd_config_file        = $::realmd::params::sssd_config_file,
-  $sssd_config_cache_file  = $::realmd::params::sssd_config_cache_file,
-  $sssd_config             = $::realmd::params::sssd_config,
-  $manage_sssd_config      = $::realmd::params::manage_sssd_config,
-  $mkhomedir_package_names = $::realmd::params::mkhomedir_package_names,
-  $domain                  = $::realmd::params::domain,
-  $domain_join_user        = $::realmd::params::domain_join_user,
-  $domain_join_password    = $::realmd::params::domain_join_password,
-  $krb_ticket_join         = $::realmd::params::krb_ticket_join,
-  $krb_keytab              = $::realmd::params::krb_keytab,
-  $krb_config_file         = $::realmd::params::krb_config_file,
-  $krb_config              = $::realmd::params::krb_config,
-  $manage_krb_config       = $::realmd::params::manage_krb_config,
+  $realmd_package_name             = $::realmd::params::realmd_package_name,
+  $realmd_config_file              = $::realmd::params::realmd_config_file,
+  $realmd_config                   = $::realmd::params::realmd_config,
+  $adcli_package_name              = $::realmd::params::adcli_package_name,
+  $krb_client_package_name         = $::realmd::params::krb_client_package_name,
+  $sssd_package_name               = $::realmd::params::sssd_package_name,
+  $sssd_service_name               = $::realmd::params::sssd_service_name,
+  $sssd_config_file                = $::realmd::params::sssd_config_file,
+  $sssd_config_cache_file          = $::realmd::params::sssd_config_cache_file,
+  $sssd_config                     = $::realmd::params::sssd_config,
+  $manage_sssd_config              = $::realmd::params::manage_sssd_config,
+  $mkhomedir_package_names         = $::realmd::params::mkhomedir_package_names,
+  $samba_common_tools_package_name = $::realmd::params::samba_common_tools_package_name,
+  $domain                          = $::realmd::params::domain,
+  $domain_join_user                = $::realmd::params::domain_join_user,
+  $domain_join_password            = $::realmd::params::domain_join_password,
+  $krb_ticket_join                 = $::realmd::params::krb_ticket_join,
+  $krb_keytab                      = $::realmd::params::krb_keytab,
+  $krb_config_file                 = $::realmd::params::krb_config_file,
+  $krb_config                      = $::realmd::params::krb_config,
+  $manage_krb_config               = $::realmd::params::manage_krb_config,
 ) inherits ::realmd::params {
 
   if $krb_ticket_join == false {
@@ -59,6 +60,7 @@ class realmd (
     $domain,
     $domain_join_user,
     $domain_join_password,
+    $samba_common_tools_package_name,
   )
 
   validate_absolute_path(

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class realmd (
   $sssd_config                     = $::realmd::params::sssd_config,
   $manage_sssd_config              = $::realmd::params::manage_sssd_config,
   $mkhomedir_package_names         = $::realmd::params::mkhomedir_package_names,
-  $samba_common_tools_package_name = $::realmd::params::samba_common_tools_package_name,
+  $extra_packages                  = $::realmd::params::extra_packages,
   $domain                          = $::realmd::params::domain,
   $domain_join_user                = $::realmd::params::domain_join_user,
   $domain_join_password            = $::realmd::params::domain_join_password,
@@ -60,7 +60,6 @@ class realmd (
     $domain,
     $domain_join_user,
     $domain_join_password,
-    $samba_common_tools_package_name,
   )
 
   validate_absolute_path(

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,7 @@ class realmd::install {
     $::realmd::krb_client_package_name,
     $::realmd::sssd_package_name,
     $::realmd::mkhomedir_package_names,
+    $::realmd::samba_common_tools_package_name,
   ]
   $_packages = flatten($_package_list)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,7 +9,7 @@ class realmd::install {
     $::realmd::krb_client_package_name,
     $::realmd::sssd_package_name,
     $::realmd::mkhomedir_package_names,
-    $::realmd::samba_common_tools_package_name,
+    $::realmd::extra_packages,
   ]
   $_packages = flatten($_package_list)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class realmd::params {
         'oddjob',
         'oddjob-mkhomedir',
       ]
-      $samba_common_tools_package_name = 'samba_common_tools'
+      $extra_packages                  = []
       $domain                          = $::domain
       $domain_join_user                = undef
       $domain_join_password            = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,28 +6,29 @@
 class realmd::params {
   case $::osfamily {
     'RedHat', 'Amazon': {
-      $realmd_package_name     = 'realmd'
-      $realmd_config_file      = '/etc/realmd.conf'
-      $realmd_config           = {}
-      $adcli_package_name      = 'adcli'
-      $krb_client_package_name = 'krb5-workstation'
-      $sssd_package_name       = 'sssd'
-      $sssd_service_name       = 'sssd'
-      $sssd_config_file        = '/etc/sssd/sssd.conf'
-      $sssd_config_cache_file  = '/var/lib/sss/db/config.ldb'
-      $sssd_config             = {}
-      $manage_sssd_config      = false
-      $mkhomedir_package_names = [
+      $realmd_package_name             = 'realmd'
+      $realmd_config_file              = '/etc/realmd.conf'
+      $realmd_config                   = {}
+      $adcli_package_name              = 'adcli'
+      $krb_client_package_name         = 'krb5-workstation'
+      $sssd_package_name               = 'sssd'
+      $sssd_service_name               = 'sssd'
+      $sssd_config_file                = '/etc/sssd/sssd.conf'
+      $sssd_config_cache_file          = '/var/lib/sss/db/config.ldb'
+      $sssd_config                     = {}
+      $manage_sssd_config              = false
+      $mkhomedir_package_names         = [
         'oddjob',
         'oddjob-mkhomedir',
       ]
-      $domain                  = $::domain
-      $domain_join_user        = undef
-      $domain_join_password    = undef
-      $krb_ticket_join         = false
-      $krb_keytab              = undef
-      $krb_config_file         = '/etc/krb5.conf'
-      $krb_config              = {
+      $samba_common_tools_package_name = 'samba_common_tools'
+      $domain                          = $::domain
+      $domain_join_user                = undef
+      $domain_join_password            = undef
+      $krb_ticket_join                 = false
+      $krb_keytab                      = undef
+      $krb_config_file                 = '/etc/krb5.conf'
+      $krb_config                      = {
         'logging' => {
           'default' => 'FILE:/var/log/krb5libs.log',
         },
@@ -38,7 +39,7 @@ class realmd::params {
           'kdc_timesync'     => '0',
         },
       }
-      $manage_krb_config       = true
+      $manage_krb_config               = true
     }
     'Debian': {
       $realmd_package_name     = 'realmd'


### PR DESCRIPTION
After looking at the code i found that the only one of the packages i needed that was not installing was samba-common-tools this package is required for CENTOS 7. 