### PR TITLE
Adding systemd service option for centos7 + Samba Common Tools

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class realmd (
   $krb_config_file         = $::realmd::params::krb_config_file,
   $krb_config              = $::realmd::params::krb_config,
   $manage_krb_config       = $::realmd::params::manage_krb_config,
+  $init_style              = $::realmd::params::init_style,
 ) inherits ::realmd::params {
 
   if $krb_ticket_join == false {
@@ -85,10 +86,10 @@ class realmd (
 
   if $krb_keytab { validate_absolute_path($krb_keytab) }
 
-  class { '::realmd::install': } ->
-  class { '::realmd::config': } ~>
-  class { '::realmd::join': } ->
-  class { '::realmd::sssd::config': }~>
-  class { '::realmd::sssd::service': }
+  class { '::realmd::install': }
+  -> class { '::realmd::config': }
+  ~> class { '::realmd::join': }
+  -> class { '::realmd::sssd::config': }
+  ~> class { '::realmd::sssd::service': }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class realmd::params {
       $mkhomedir_package_names = [
         'oddjob',
         'oddjob-mkhomedir',
+        'samba-common-tools',
       ]
       $domain                  = $::domain
       $domain_join_user        = undef
@@ -81,5 +82,52 @@ class realmd::params {
     default: {
       fail("${::operatingsystem} not supported")
     }
+  }
+
+  if $::operatingsystem == 'Ubuntu' {
+    if versioncmp($::operatingsystemrelease, '8.04') < 1 {
+      $init_style = 'debian'
+    } elsif versioncmp($::operatingsystemrelease, '15.04') < 0 {
+      $init_style = 'upstart'
+    } else {
+      $init_style = 'systemd'
+    }
+  } elsif $::operatingsystem =~ /Scientific|CentOS|RedHat|OracleLinux/ {
+    if versioncmp($::operatingsystemrelease, '7.0') < 0 {
+      $init_style = 'service'
+    } else {
+      $init_style  = 'systemd'
+    }
+  } elsif $::operatingsystem == 'Fedora' {
+    if versioncmp($::operatingsystemrelease, '12') < 0 {
+      $init_style = 'service'
+    } else {
+      $init_style = 'systemd'
+    }
+  } elsif $::operatingsystem == 'Debian' {
+    if versioncmp($::operatingsystemrelease, '8.0') < 0 {
+      $init_style = 'debian'
+    } else {
+      $init_style = 'systemd'
+    }
+  } elsif $::operatingsystem == 'Archlinux' {
+    $init_style = 'systemd'
+  } elsif $::operatingsystem == 'OpenSuSE' {
+    $init_style = 'systemd'
+  } elsif $::operatingsystem =~ /SLE[SD]/ {
+    if versioncmp($::operatingsystemrelease, '12.0') < 0 {
+      $init_style = 'sles'
+    } else {
+      $init_style = 'systemd'
+    }
+  } elsif $::operatingsystem == 'Darwin' {
+    $init_style = 'launchd'
+  } elsif $::operatingsystem == 'Amazon' {
+    $init_style = 'service'
+  } else {
+    $init_style = undef
+  }
+  if $init_style == undef {
+    fail('Unsupported OS')
   }
 }

--- a/manifests/sssd/service.pp
+++ b/manifests/sssd/service.pp
@@ -12,6 +12,7 @@ class realmd::sssd::service {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
+    provider   => $::realmd::init_style,
   }
 
 }


### PR DESCRIPTION
Hi there,

I have seen that service restart sssd is not working for centos7, from manually testing seems that sssd ask systemctl restart sssd comand . Whit this commit I`ll add smaba-common-tools which is required for centos 7 and systemd service option.

Greetings
Karen