### PR TITLE
added support for ou join paramter, to specify context of the server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class realmd (
   Stdlib::Absolutepath $krb_config_file,
   Hash $krb_config,
   Boolean $manage_krb_config,
+  String $ou,
   Hash $required_packages,
 ) {
 

--- a/manifests/join/keytab.pp
+++ b/manifests/join/keytab.pp
@@ -11,6 +11,7 @@ class realmd::join::keytab {
   $_krb_config_file   = $::realmd::krb_config_file
   $_krb_config        = $::realmd::krb_config
   $_manage_krb_config = $::realmd::manage_krb_config
+  $_ou                = $::realmd::ou
 
   $_krb_config_final = deep_merge({'libdefaults' => {'default_realm' => upcase($::domain)}}, $_krb_config)
 
@@ -41,11 +42,24 @@ class realmd::join::keytab {
     before  => Exec['realm_join_with_keytab'],
   }
 
+if $_ou != undef {
+  exec { 'realm_join_with_keytab':
+    path    => '/usr/bin:/usr/sbin:/bin',
+    command => "realm join ${_domain} --computer-ou=${_ou}",
+    unless  => 'kinit -k host/$(hostname -f)',
+    require => Exec['run_kinit_with_keytab'],
+}
+
+else {
   exec { 'realm_join_with_keytab':
     path    => '/usr/bin:/usr/sbin:/bin',
     command => "realm join ${_domain}",
     unless  => 'kinit -k host/$(hostname -f)',
     require => Exec['run_kinit_with_keytab'],
+
+}
+  
+
   }
 
 }

--- a/manifests/join/keytab.pp
+++ b/manifests/join/keytab.pp
@@ -48,6 +48,7 @@ if $_ou != undef {
     command => "realm join ${_domain} --computer-ou=${_ou}",
     unless  => 'kinit -k host/$(hostname -f)',
     require => Exec['run_kinit_with_keytab'],
+  }
 }
 
 else {
@@ -56,10 +57,5 @@ else {
     command => "realm join ${_domain}",
     unless  => 'kinit -k host/$(hostname -f)',
     require => Exec['run_kinit_with_keytab'],
-
-}
-  
-
   }
-
 }

--- a/manifests/join/keytab.pp
+++ b/manifests/join/keytab.pp
@@ -59,3 +59,4 @@ else {
     require => Exec['run_kinit_with_keytab'],
   }
 }
+}

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -8,11 +8,22 @@ class realmd::join::password {
   $_domain    = $::realmd::domain
   $_user      = $::realmd::domain_join_user
   $_password  = $::realmd::domain_join_password
+  $_ou        = $::realmd::ou
 
+if $_ou != undef {
+    exec { 'realm_join_with_password':
+    path    => '/usr/bin:/usr/sbin:/bin',
+    command => "echo '${_password}' | realm join ${_domain} --unattended --computer-ou=${_ou} --user=${_user}",
+    unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
+  }
+}
+
+else {
   exec { 'realm_join_with_password':
     path    => '/usr/bin:/usr/sbin:/bin',
     command => "echo '${_password}' | realm join ${_domain} --unattended --user=${_user}",
     unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
   }
+}
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class realmd::params {
   $krb_keytab             = undef
   $krb_config_file        = '/etc/krb5.conf'
   $manage_krb_config      = true
+  $ou                     = undef
   $krb_config             = {
     'logging' => {
       'default' => 'FILE:/var/log/krb5libs.log',


### PR DESCRIPTION
added support for the ou paramter for joining the AD.
rebase was quite complex and the feature easy, so I just readded it to a new fork.
 
Example for hieradata for new paprameter:

realm::ou: "OU=Servers,OU=All_Computers,DC=demo,DC=com"

