### PR TITLE
Conceal the AD join password using an ENV var

### DIFF
--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -18,10 +18,19 @@ class realmd::join::password {
 
   $_args = join($_realm_args, ' ')
 
-  exec { 'realm_join_with_password':
-    path    => '/usr/bin:/usr/sbin:/bin',
-    command => "echo '${_password}' | realm join ${_args}",
-    unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
+  file { '/usr/libexec/realm_join_with_password':
+    ensure  => file,
+    owner   => '0',
+    group   => '0',
+    mode    => '0755',
+    content => template('realmd/realm_join_with_password.erb'),
   }
 
+  exec { 'realm_join_with_password':
+    environment => ["AD_JOIN_PASSWORD=${_password}"],
+    path        => '/usr/bin:/usr/sbin:/bin',
+    command     => "/usr/libexec/realm_join_with_password realm join ${_domain} --unattended --user=${_user}",
+    unless      => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
+    require     => File['/usr/libexec/realm_join_with_password'],
+  }
 }

--- a/templates/realm_join_with_password.erb
+++ b/templates/realm_join_with_password.erb
@@ -1,0 +1,10 @@
+#! /bin/bash
+set -e
+set -u
+
+if [ -z "$AD_JOIN_PASSWORD" ]; then
+  echo "ERROR: AD_JOIN_PASSWORD environment variable is unset or empty." >&2
+  exit 2
+fi
+
+"$@" <<< "$AD_JOIN_PASSWORD"


### PR DESCRIPTION
Without this patch the AD join password is shown in the Puppet logs:

    Aug 15 16:42:10 agent1 puppet-agent[2476]: \
      (/Stage[main]/Realmd::Join::Password/Exec[realm_join_with_password]/returns) \
      change from notrun to 0 failed: echo  Password1' | realm join puppet.vm \
      --unattended --user=Administrator returned 1 instead of one of [0]

This patch addresses the problem by wrapping the redirection in a shell script
and reading the password from an environment variable set by Puppet.  This
prevents the password from showing up in the Puppet logs or in the process
table.

Resolves #9