### PR TITLE
Enable changing of default umask for mkhomedir.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -122,6 +122,7 @@ Default values are in params.pp.
 * `realmd_package_name`: String. The name of the main Realmd package.
 * `realmd_config_file`: String. The absolute path of the Realmd configuration file.
 * `realmd_config`: Hash. A hash of configuration options structured in an ini-style format.
+* `homedir_umask`: String. A string of the umask for the default directory permissions created by mkhomedir with Debian.
 * `adcli_package_name`: String. The name of the adcli package
 * `krb_client_package_name`: String. The name of the Kerberos client package.
 * `sssd_package_name`: String. The name of the main SSSD package.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,7 @@ realmd::realmd_package_name: realmd
 realmd::realmd_package_ensure: present
 realmd::realmd_config_file: /etc/realmd.conf
 realmd::realmd_config: {}
+realmd::homedir_umask: '0022'
 realmd::adcli_package_name: adcli
 realmd::adcli_package_ensure: present
 realmd::sssd_package_name: sssd

--- a/files/realmd_mkhomedir
+++ b/files/realmd_mkhomedir
@@ -1,6 +1,0 @@
-Name: Make home directory for new logins
-Default: yes
-Priority: 900
-Session-Type: Additional
-Session:
-        required                        pam_mkhomedir.so umask=0022 skel=/etc/skel

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@ class realmd::config {
 
   $_realmd_config      = $::realmd::realmd_config
   $_realmd_config_file = $::realmd::realmd_config_file
+  $_realmd_home_umask  = $::realmd::homedir_umask
 
   file { $_realmd_config_file:
     ensure  => file,
@@ -17,12 +18,12 @@ class realmd::config {
 
   if $::osfamily == 'Debian' {
     file { '/usr/share/pam-configs/realmd_mkhomedir':
-      ensure => file,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-      source => 'puppet:///modules/realmd/realmd_mkhomedir',
-      notify => Exec['realm-pam-auth-update'],
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('realmd/realmd_mkhomedir.erb'),
+      notify  => Exec['realm-pam-auth-update'],
     }
 
     exec { 'realm-pam-auth-update':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class realmd (
   String $realmd_package_ensure,
   Stdlib::Absolutepath $realmd_config_file,
   Hash $realmd_config,
+  String $homedir_umask,
   String $adcli_package_name,
   String $adcli_package_ensure,
   String $krb_client_package_name,

--- a/templates/realmd_mkhomedir.erb
+++ b/templates/realmd_mkhomedir.erb
@@ -1,0 +1,6 @@
+Name: Make home directory for new logins
+Default: yes
+Priority: 900
+Session-Type: Additional
+Session:
+        required                        pam_mkhomedir.so umask=<%= @_realmd_home_umask %> skel=/etc/skel


### PR DESCRIPTION
For local security policies, we can't allow world-readable home directories, this patch templates the mkhomedir for PAM so the umask can be changed to suit our policies.