### PR TITLE
Fixed _realm_args and the join command

### DIFF
--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -13,7 +13,7 @@ class realmd::join::password {
   notify {"OU=${_ou}":}
 
   if $_ou != undef {
-    $_realm_args = [$_domain, '--unattended', "--computer-ou=OU=${_ou}", "--user=${_user}"]
+    $_realm_args = [$_domain, '--unattended', "--computer-ou=${_ou}", "--user=${_user}"]
   } else {
     $_realm_args = [$_domain, '--unattended', "--user=${_user}"]
   }

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -10,8 +10,6 @@ class realmd::join::password {
   $_password  = $::realmd::domain_join_password
   $_ou        = $::realmd::ou
 
-  notify {"OU=${_ou}":}
-
   if $_ou != undef {
     $_realm_args = [$_domain, '--unattended', "--computer-ou=OU=${_ou}", "--user=${_user}"]
   } else {
@@ -19,8 +17,6 @@ class realmd::join::password {
   }
 
   $_args = join($_realm_args, ' ')
-
-  notify {"ARGS=${_args}":}
 
   file { '/usr/libexec/realm_join_with_password':
     ensure  => file,
@@ -33,7 +29,6 @@ class realmd::join::password {
   exec { 'realm_join_with_password':
     environment => ["AD_JOIN_PASSWORD=${_password}"],
     path        => '/usr/bin:/usr/sbin:/bin',
-    #command     => "/usr/libexec/realm_join_with_password realm join ${_domain} --unattended --user=${_user}",
     command     => "/usr/libexec/realm_join_with_password realm join ${_args}",
     unless      => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
     require     => File['/usr/libexec/realm_join_with_password'],

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -13,7 +13,7 @@ class realmd::join::password {
   notify {"OU=${_ou}":}
 
   if $_ou != undef {
-    $_realm_args = [$_domain, '--unattended', "--computer-ou=${_ou}", "--user=${_user}"]
+    $_realm_args = [$_domain, '--unattended', "--computer-ou=OU=${_ou}", "--user=${_user}"]
   } else {
     $_realm_args = [$_domain, '--unattended', "--user=${_user}"]
   }

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -13,7 +13,7 @@ class realmd::join::password {
   notify {"OU=${_ou}":}
 
   if $_ou != undef {
-    $_realm_args = [$_domain, '--unattended', "--computer-ou==OU=${_ou}", "--user=${_user}"]
+    $_realm_args = [$_domain, '--unattended', "--computer-ou=OU=${_ou}", "--user=${_user}"]
   } else {
     $_realm_args = [$_domain, '--unattended', "--user=${_user}"]
   }

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -10,6 +10,8 @@ class realmd::join::password {
   $_password  = $::realmd::domain_join_password
   $_ou        = $::realmd::ou
 
+  notify {"OU=${_ou}":}
+
   if $_ou != undef {
     $_realm_args = [$_domain, '--unattended', "--computer-ou=${_ou}", "--user=${_user}"]
   } else {
@@ -17,6 +19,8 @@ class realmd::join::password {
   }
 
   $_args = join($_realm_args, ' ')
+
+  notify {"ARGS=${_args}":}
 
   file { '/usr/libexec/realm_join_with_password':
     ensure  => file,
@@ -29,7 +33,8 @@ class realmd::join::password {
   exec { 'realm_join_with_password':
     environment => ["AD_JOIN_PASSWORD=${_password}"],
     path        => '/usr/bin:/usr/sbin:/bin',
-    command     => "/usr/libexec/realm_join_with_password realm join ${_domain} --unattended --user=${_user}",
+    #command     => "/usr/libexec/realm_join_with_password realm join ${_domain} --unattended --user=${_user}",
+    command     => "/usr/libexec/realm_join_with_password realm join ${_args}",
     unless      => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
     require     => File['/usr/libexec/realm_join_with_password'],
   }

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -13,7 +13,7 @@ class realmd::join::password {
   notify {"OU=${_ou}":}
 
   if $_ou != undef {
-    $_realm_args = [$_domain, '--unattended', "--computer-ou=${_ou}", "--user=${_user}"]
+    $_realm_args = [$_domain, '--unattended', "--computer-ou==OU=${_ou}", "--user=${_user}"]
   } else {
     $_realm_args = [$_domain, '--unattended', "--user=${_user}"]
   }


### PR DESCRIPTION
The _real_args --computer-ou needed to have =OU=$_ou and then updated the realmd join command to use the _args param.

This now joins the machine to AD and puts it into the desired OU. 

Thanks for the work on the rest of the module.