### PR TITLE
Added single quotes to OU to allow for OU structures containing spaces

### DIFF
--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -11,7 +11,7 @@ class realmd::join::password {
   $_ou        = $::realmd::ou
 
   if $_ou != undef {
-    $_realm_args = [$_domain, '--unattended', "--computer-ou=OU=${_ou}", "--user=${_user}"]
+    $_realm_args = [$_domain, '--unattended', "--computer-ou='OU=${_ou}'", "--user=${_user}"]
   } else {
     $_realm_args = [$_domain, '--unattended', "--user=${_user}"]
   }


### PR DESCRIPTION
We have numerous OU's in our AD that have spaces contained in their names, hence the command line was breaking.