### PR TITLE
Ensure /usr/libexec exists (Issue #31)

### DIFF
--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -17,6 +17,10 @@ class realmd::join::password {
   }
 
   $_args = join($_realm_args, ' ')
+  
+  file { '/usr/libexec':
+    ensure  => 'directory',
+  }
 
   file { '/usr/libexec/realm_join_with_password':
     ensure  => file,


### PR DESCRIPTION
Closes #31.  /usr/libexec is an optional directory according to the current Linux FHS (v2.3), meaning it does not exist by default on some distros (namely Ubuntu and Debian) and needs to be ensured before placing files there