### PR TITLE
Allow user to specify additional options to "realm join"

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -24,6 +24,7 @@ realmd::krb_config_file: /etc/krb5.conf
 realmd::manage_krb_config: true
 realmd::krb_client_package_ensure: present
 realmd::extra_join_options: ~
+realmd::computer_name: ~
 realmd::krb_config:
   logging:
     default: FILE:/var/log/krb5libs.log

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -23,6 +23,7 @@ realmd::krb_keytab: ~
 realmd::krb_config_file: /etc/krb5.conf
 realmd::manage_krb_config: true
 realmd::krb_client_package_ensure: present
+realmd::extra_join_options: ~
 realmd::krb_config:
   logging:
     default: FILE:/var/log/krb5libs.log

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ class realmd (
   Variant[String, Undef] $ou,
   Hash $required_packages,
   Variant[Array, Undef] $extra_join_options,
+  Variant[String[1, 15], Undef] $computer_name,
 ) {
 
   if $krb_ticket_join == false {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,7 @@ class realmd (
   Boolean $manage_krb_config,
   Variant[String, Undef] $ou,
   Hash $required_packages,
+  Variant[Array, Undef] $extra_join_options,
 ) {
 
   if $krb_ticket_join == false {

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -14,7 +14,7 @@ class realmd::join::password {
   if $::realmd::computer_name != undef {
     $_computer_name = $::realmd::computer_name
   } else {
-    $_computer_name = "${::hostname[0,15]}"
+    $_computer_name = $::hostname[0,15]
   }
 
   $_computer_name_arg = ["--computer-name=${_computer_name}"]

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -5,10 +5,11 @@
 #
 class realmd::join::password {
 
-  $_domain    = $::realmd::domain
-  $_user      = $::realmd::domain_join_user
-  $_password  = $::realmd::domain_join_password
-  $_ou        = $::realmd::ou
+  $_domain             = $::realmd::domain
+  $_user               = $::realmd::domain_join_user
+  $_password           = $::realmd::domain_join_password
+  $_ou                 = $::realmd::ou
+  $_extra_join_options = $::realmd::extra_join_options
 
   if $_ou != undef {
     $_realm_args = [$_domain, '--unattended', "--computer-ou='OU=${_ou}'", "--user=${_user}"]
@@ -16,7 +17,7 @@ class realmd::join::password {
     $_realm_args = [$_domain, '--unattended', "--user=${_user}"]
   }
 
-  $_args = join($_realm_args, ' ')
+  $_args = join(concat($_realm_args, $_extra_join_options), ' ')
 
   file { '/usr/libexec':
     ensure  => 'directory',

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -17,7 +17,7 @@ class realmd::join::password {
     $_realm_args = [$_domain, '--unattended', "--user=${_user}"]
   }
 
-  $_args = join(concat($_realm_args, $_extra_join_options), ' ')
+  $_args = strip(join(concat($_realm_args, $_extra_join_options), ' '))
 
   file { '/usr/libexec':
     ensure  => 'directory',

--- a/spec/classes/join__password_spec.rb
+++ b/spec/classes/join__password_spec.rb
@@ -22,7 +22,7 @@ describe 'realmd' do
           it do
             is_expected.to contain_exec('realm_join_with_password').with({
               'path'    => '/usr/bin:/usr/sbin:/bin',
-              'command' => '/usr/libexec/realm_join_with_password realm join example.com --unattended --user=user',
+              'command' => '/usr/libexec/realm_join_with_password realm join example.com --unattended --user=user --computer-name=foo',
               'unless'  => "klist -k /etc/krb5.keytab | grep -i 'foo@example.com'",
             })
           end


### PR DESCRIPTION
My use case is specifically for passing --computer-name - by default realm will truncate hostname to 15 characters and there is chance that one will end up duplicating computer objects in AD.