### PR TITLE
Allow joining without password or on time password

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -82,6 +82,26 @@ Setup realmd and join an Active Directory domain via username and password:
       domain_join_password => 'password',
     }
 
+### Joining with a prepared computer account
+1. Create the computer account by running adcli on *any* domain joined machine
+  * new computer account: `/usr/sbin/adcli preset-computer --domain example.com`
+  * or use an existing account: `/usr/sbin/adcli reset-computer --domain example.com`
+2. Configure the realmd class
+
+```
+    class { '::realmd':
+      domain             => $::domain,
+      one_time_password  => 's3cure_pw', #optional, skip if you didn't specify it when running preset-computer# 
+      #do not set domain_join_user
+      #do not set krb_ticket_join
+    }
+```
+
+#### Errors when running wio
+1. `Error: adcli join ... returned 3 instead of one of [0]`
+
+The account hasn't been prepared properly or the password is wrong
+
 ## Usage
 
 Set up Realmd, join an Active Directory domain via a keytab and fully configure SSSD:
@@ -134,6 +154,7 @@ Default values are in params.pp.
 * `domain`: String. The name of the domain to join.
 * `domain_join_user`: String. The account to be used in joining the domain.
 * `domain_join_password`: String. The password of the account to be used in joining the domain.
+* `one_time_password`: The password of the prepared computeraccount.
 * `krb_ticket_join`: Boolean. Enable of disable joining the domain via a Kerberos keytab.
 * `krb_keytab`: String. The absolute path to the Kerberos keytab file to be used in joining the domain.
 * `krb_config_file`: String. The absolute path to the Kerberos client configuration file.
@@ -147,6 +168,7 @@ Default values are in params.pp.
 * realmd::join
 * realmd::join::password
 * realmd::join::keytab
+* realmd::join::one_time_password
 * realmd::sssd::config
 * realmd::sssd::service
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,7 +19,7 @@ realmd::domain_join_user: ~
 realmd::domain_join_password: ~
 realmd::one_time_password: ~
 realmd::ou: ~
-realmd::netbiosname: ~
+realmd::netbiosname: ''
 realmd::krb_ticket_join: false
 realmd::krb_keytab: ~
 realmd::krb_config_file: /etc/krb5.conf

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,6 +19,7 @@ realmd::domain_join_user: ~
 realmd::domain_join_password: ~
 realmd::one_time_password: ~
 realmd::ou: ~
+realmd::netbiosname: ~
 realmd::krb_ticket_join: false
 realmd::krb_keytab: ~
 realmd::krb_config_file: /etc/krb5.conf

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,6 +17,7 @@ realmd::manage_sssd_config: false
 realmd::domain: "%{::domain}"
 realmd::domain_join_user: ~
 realmd::domain_join_password: ~
+realmd::one_time_password: ~
 realmd::ou: ~
 realmd::krb_ticket_join: false
 realmd::krb_keytab: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@ class realmd (
   Hash $sssd_config,
   Boolean $manage_sssd_config,
   String $domain,
-  Variant[String, Undef] $netbiosname,
+  String $netbiosname,
   Variant[String, Undef] $domain_join_user,
   Variant[String, Undef] $domain_join_password,
   Variant[String, Undef] $one_time_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@ class realmd (
   Hash $sssd_config,
   Boolean $manage_sssd_config,
   String $domain,
+  Variant[String, Undef] $netbiosname,
   Variant[String, Undef] $domain_join_user,
   Variant[String, Undef] $domain_join_password,
   Variant[String, Undef] $one_time_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class realmd (
   String $domain,
   Variant[String, Undef] $domain_join_user,
   Variant[String, Undef] $domain_join_password,
+  Variant[String, Undef] $one_time_password,
   Boolean $krb_ticket_join,
   Variant[Stdlib::Absolutepath, Undef] $krb_keytab,
   Stdlib::Absolutepath $krb_config_file,
@@ -49,6 +50,9 @@ class realmd (
   }
   if ($domain_join_password and !$domain_join_user) {
     fail('Cannot set domain_join_password without domain_join_user')
+  }
+  if ($one_time_password and $domain_join_user) {
+    fail('Cannot do a machine login with one_time_password, when a domain_join_user is set')
   }
 
   if $manage_sssd_config and empty($sssd_config) {

--- a/manifests/join.pp
+++ b/manifests/join.pp
@@ -8,7 +8,12 @@ class realmd::join {
     contain '::realmd::join::keytab'
   }
   else {
-    contain '::realmd::join::password'
+    if $::realmd::domain_join_user {
+        contain '::realmd::join::password'
+    }
+    else {
+        contain '::realmd::join::one_time_password'
+    }
   }
 
 }

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -8,6 +8,7 @@
 class realmd::join::one_time_password {
 
   $_domain            = $::realmd::domain
+  $_netbiosname       = $::realmd::netbiosname
   $_ou                = $::realmd::ou
   $_krb_config_file   = $::realmd::krb_config_file
   $_krb_config        = $::realmd::krb_config
@@ -15,10 +16,10 @@ class realmd::join::one_time_password {
 
   $_krb_config_final = deep_merge({'libdefaults' => {'default_realm' => upcase($::domain)}}, $_krb_config)
   if !$::realmd::one_time_password  {
-      $_password=$::hostname[0,15]
-  }
-  else {
-      $_password=$::realmd::one_time_password
+        $_password=$::hostname[0,15]
+    }
+    else {
+        $_password=$::realmd::one_time_password
   }
   $_realm=upcase($::realmd::domain)
   $_fqdn=$::fqdn
@@ -34,7 +35,11 @@ class realmd::join::one_time_password {
     }
   }
 
-  $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer']
+  if !empty($_netbiosname) {
+    $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer', "--computer-name=${_netbiosname}"]
+  } else {
+    $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer']
+  }
 
   if $_ou != undef {
       $_ou_args=["--computer-ou='OU=${_ou}'"]

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -1,0 +1,61 @@
+# == Class realmd::join::password
+#
+# This class is called from realmd for
+# joining AD using a username and password.
+# The default password for Windows ADS is 
+# "the first 15 chars of the hostname in lowercase"
+#
+class realmd::join::one_time_password {
+
+  $_domain            = $::realmd::domain
+  $_ou                = $::realmd::ou
+  $_krb_config_file   = $::realmd::krb_config_file
+  $_krb_config        = $::realmd::krb_config
+  $_manage_krb_config = $::realmd::manage_krb_config
+
+  $_krb_config_final = deep_merge({'libdefaults' => {'default_realm' => upcase($::domain)}}, $_krb_config)
+  if !$::realmd::one_time_password  {
+      $_password=$::hostname[0,15]
+  }
+  else {
+      $_password=$::realmd::one_time_password
+  }
+
+
+  if $_manage_krb_config {
+    file { 'krb_configuration':
+      ensure  => file,
+      path    => $_krb_config_file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('realmd/krb5.conf.erb'),
+    }
+  }
+
+  $_domain_args = ["--domain=${_domain}" ]
+
+  if $_ou != undef {
+      $_ou_args=["--computer-ou='OU=${_ou}'"]
+  }
+  else {
+      $_ou_args=[]
+  }
+  
+  if $::realmd::one_time_password != undef {
+      $_password_args=["--one-time-password='${$::realmd::one_time_password}'"]
+  }
+  else {
+      $_password_args=[]
+  }
+
+
+  $_args = join(concat( $_domain_args, $_ou_args, $_password_args), ' ')
+
+
+  exec { 'realm_join_one_time_password':
+    path    => '/usr/bin:/usr/sbin:/bin',
+    command => "adcli join ${_args}",
+    unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
+  }
+}

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -20,7 +20,8 @@ class realmd::join::one_time_password {
   else {
       $_password=$::realmd::one_time_password
   }
-
+  $_realm=upcase($::realmd::domain)
+  $_fqdn=$::fqdn
 
   if $_manage_krb_config {
     file { 'krb_configuration':
@@ -33,7 +34,7 @@ class realmd::join::one_time_password {
     }
   }
 
-  $_domain_args = ["--domain=${_domain}" ]
+  $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", "--login-type=computer"]
 
   if $_ou != undef {
       $_ou_args=["--computer-ou='OU=${_ou}'"]
@@ -41,17 +42,16 @@ class realmd::join::one_time_password {
   else {
       $_ou_args=[]
   }
-  
+
   if $::realmd::one_time_password != undef {
       $_password_args=["--one-time-password='${$::realmd::one_time_password}'"]
   }
   else {
-      $_password_args=[]
+      $_password_args=["--no-password"]
   }
 
 
   $_args = join(concat( $_domain_args, $_ou_args, $_password_args), ' ')
-
 
   exec { 'realm_join_one_time_password':
     path    => '/usr/bin:/usr/sbin:/bin',

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -37,7 +37,8 @@ class realmd::join::one_time_password {
 
   if !empty($_netbiosname) {
     $_check_pricipal = $_netbiosname
-    $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer', "--computer-name=${_netbiosname}"]
+    $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}",
+                    '--login-type=computer', "--computer-name=${_netbiosname}"]
   } else {
     $_check_pricipal = $::hostname[0,15]
     $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer']

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -34,7 +34,7 @@ class realmd::join::one_time_password {
     }
   }
 
-  $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", "--login-type=computer"]
+  $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer']
 
   if $_ou != undef {
       $_ou_args=["--computer-ou='OU=${_ou}'"]
@@ -47,7 +47,7 @@ class realmd::join::one_time_password {
       $_password_args=["--one-time-password='${$::realmd::one_time_password}'"]
   }
   else {
-      $_password_args=["--no-password"]
+      $_password_args=['--no-password']
   }
 
 

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -36,8 +36,10 @@ class realmd::join::one_time_password {
   }
 
   if !empty($_netbiosname) {
+    $_check_pricipal = $_netbiosname
     $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer', "--computer-name=${_netbiosname}"]
   } else {
+    $_check_pricipal = $::hostname[0,15]
     $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer']
   }
 
@@ -61,6 +63,6 @@ class realmd::join::one_time_password {
   exec { 'realm_join_one_time_password':
     path    => '/usr/bin:/usr/sbin:/bin',
     command => "adcli join ${_args}",
-    unless  => "klist -k /etc/krb5.keytab | grep -i '${::hostname[0,15]}@${_domain}'",
+    unless  => "klist -k /etc/krb5.keytab | grep -i '${_check_pricipal}@${_domain}'",
   }
 }

--- a/spec/classes/join__one_time_password_spec.rb
+++ b/spec/classes/join__one_time_password_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'realmd' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      # test with custom password
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+
+        context "realmd::join::one_time_password class" do
+          let(:params) do
+            {
+              :one_time_password => 'password',
+              :domain                        => 'example.com',
+            }
+          end
+
+          it { is_expected.to contain_class('realmd::join::one_time_password') }
+
+          it do
+            is_expected.to contain_exec('realm_join_one_time_password').with({
+              'path'    => '/usr/bin:/usr/sbin:/bin',
+              'command' => "adcli join --domain=example.com --one-time-password='password'",
+              'unless'  => "klist -k /etc/krb5.keytab | grep -i 'foo@example.com'",
+            })
+          end
+        end
+      end
+
+      # test with long hostname
+      context "on #{os}" do
+        let(:facts) do
+            facts.merge({
+                :hostname => 'to_long_hostname',
+            })
+        end
+        
+        context "realmd::join::one_time_password class" do
+          let(:params) do
+            {
+#              :one_time_password => 'to_long_hostnam',
+              :domain                        => 'example.com',
+            }
+          end
+
+          it { is_expected.to contain_class('realmd::join::one_time_password') }
+
+          it do
+            is_expected.to contain_exec('realm_join_one_time_password').with({
+              'path'    => '/usr/bin:/usr/sbin:/bin',
+              'command' => "adcli join --domain=example.com", # 'e' is removed
+              'unless'  => "klist -k /etc/krb5.keytab | grep -i 'to_long_hostnam@example.com'",
+            })
+          end
+        end
+      end
+      
+    end
+  end
+end

--- a/spec/classes/join__one_time_password_spec.rb
+++ b/spec/classes/join__one_time_password_spec.rb
@@ -22,7 +22,7 @@ describe 'realmd' do
           it do
             is_expected.to contain_exec('realm_join_one_time_password').with({
               'path'    => '/usr/bin:/usr/sbin:/bin',
-              'command' => "adcli join --domain=example.com --one-time-password='password'",
+              'command' => "adcli join --domain=example.com --user-principal=host/foo.example.com@EXAMPLE.COM --login-type=computer --one-time-password='password'",
               'unless'  => "klist -k /etc/krb5.keytab | grep -i 'foo@example.com'",
             })
           end
@@ -33,14 +33,15 @@ describe 'realmd' do
       context "on #{os}" do
         let(:facts) do
             facts.merge({
-                :hostname => 'to_long_hostname',
+                :hostname => 'to-long-hostname',
+                :domain   => 'example.com',
+                :fqdn     => 'to-long-hostname.example.com',
             })
         end
         
         context "realmd::join::one_time_password class" do
           let(:params) do
             {
-#              :one_time_password => 'to_long_hostnam',
               :domain                        => 'example.com',
             }
           end
@@ -50,8 +51,8 @@ describe 'realmd' do
           it do
             is_expected.to contain_exec('realm_join_one_time_password').with({
               'path'    => '/usr/bin:/usr/sbin:/bin',
-              'command' => "adcli join --domain=example.com", # 'e' is removed
-              'unless'  => "klist -k /etc/krb5.keytab | grep -i 'to_long_hostnam@example.com'",
+              'command' => "adcli join --domain=example.com --user-principal=host/to-long-hostname.example.com@EXAMPLE.COM --login-type=computer --no-password", 
+              'unless'  => "klist -k /etc/krb5.keytab | grep -i 'to-long-hostnam@example.com'", # 'e' is removed
             })
           end
         end


### PR DESCRIPTION
This adds the option of using precreated computer accounts to join. This allows bulk operations and continious integration. (adcli reset-computer ...)

I had to use *adcli*, since *realm* does not work for long hostnames. 
