### PR TITLE
Increase range of Puppet support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
In order to run without warnings on Puppet 5, the new upper limit is Puppet 6.0.0