### PR TITLE
Ubuntu - Support realmd without --computer-name

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Pawel Fiuto
 Tommy Speigner
 as0bu
 rsynnest
+Romiko Derbynew

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -36,7 +36,7 @@ class realmd::join::one_time_password {
   }
 
   $_computer_name_arg = ["--computer-name=${_netbiosname}"]
-  if $::lsbdistid == 'Ubuntu' and $::lsbmajdistrelease >= 16 {
+  if $::operatingsystem == 'Ubuntu' and $facts['os']['distro']['codename']  == 'xenial' {
     $_computer_name_arg  = ''
     }
 

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -36,7 +36,7 @@ class realmd::join::one_time_password {
   }
 
   $_computer_name_arg = ["--computer-name=${_netbiosname}"]
-  if $::lsbdistcodename == 'xenial' {
+  if $::lsbdistid == 'Ubuntu' and $::lsbmajdistrelease >= 16 {
     $_computer_name_arg  = ''
     }
 

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -35,10 +35,15 @@ class realmd::join::one_time_password {
     }
   }
 
+  $_computer_name_arg = ["--computer-name=${_netbiosname}"]
+  if $::lsbdistcodename == 'xenial' {
+    $_computer_name_arg  = ''
+    }
+
   if !empty($_netbiosname) {
     $_check_pricipal = $_netbiosname
     $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}",
-                    '--login-type=computer', "--computer-name=${_netbiosname}"]
+                    '--login-type=computer', $_computer_name_arg]
   } else {
     $_check_pricipal = $::hostname[0,15]
     $_domain_args = ["--domain=${_domain}", "--user-principal=host/${_fqdn}@${_realm}", '--login-type=computer']

--- a/manifests/join/one_time_password.pp
+++ b/manifests/join/one_time_password.pp
@@ -35,10 +35,11 @@ class realmd::join::one_time_password {
     }
   }
 
-  $_computer_name_arg = ["--computer-name=${_netbiosname}"]
   if $::operatingsystem == 'Ubuntu' and $facts['os']['distro']['codename']  == 'xenial' {
     $_computer_name_arg  = ''
-    }
+  } else {
+      $_computer_name_arg = ["--computer-name=${_netbiosname}"]
+  }
 
   if !empty($_netbiosname) {
     $_check_pricipal = $_netbiosname

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -19,7 +19,7 @@ class realmd::join::password {
 
   $_computer_name_arg = ["--computer-name=${_computer_name}"]
 
-  if $::lsbdistcodename == 'xenial' {
+  if $::lsbdistid == 'Ubuntu' and $::lsbmajdistrelease >= 16 {
     $_computer_name_arg  = ''
     }
 

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -17,10 +17,11 @@ class realmd::join::password {
     $_computer_name = $::hostname[0,15]
   }
 
-  $_computer_name_arg = ["--computer-name=${_computer_name}"]
   if $::operatingsystem == 'Ubuntu' and $facts['os']['distro']['codename']  == 'xenial' {
     $_computer_name_arg  = ''
-    }
+  } else {
+      $_computer_name_arg = ["--computer-name=${_computer_name}"]
+  }
 
   if $_ou != undef {
     $_realm_args = [$_domain, '--unattended', "--computer-ou='${_ou}'", "--user=${_user}"]

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -19,6 +19,10 @@ class realmd::join::password {
 
   $_computer_name_arg = ["--computer-name=${_computer_name}"]
 
+  if $::lsbdistcodename == 'xenial' {
+    $_computer_name_arg  = ''
+    }
+
   if $_ou != undef {
     $_realm_args = [$_domain, '--unattended', "--computer-ou='${_ou}'", "--user=${_user}"]
   } else {

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -18,8 +18,7 @@ class realmd::join::password {
   }
 
   $_computer_name_arg = ["--computer-name=${_computer_name}"]
-
-  if $::lsbdistid == 'Ubuntu' and $::lsbmajdistrelease >= 16 {
+  if $::operatingsystem == 'Ubuntu' and $facts['os']['distro']['codename']  == 'xenial' {
     $_computer_name_arg  = ''
     }
 


### PR DESCRIPTION
Ubuntu Xenial does not need --computer-name option with realmd.

This has been tested an confirmed on Ubuntu 16.04.
All tests pass and linted.