### PR TITLE
Add bool flag to control sssd service. Fixes #59

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -150,6 +150,7 @@ Default values are in params.pp.
 * `sssd_config_file`: String. The absolute path of the SSSD configuration file.
 * `sssd_config`: Hash. A hash of configuration options structured in an ini-style format.
 * `manage_sssd_config`: Boolean. Enable or disable management of the SSSD configuration file.
+* `manage_sssd_service`: Boolean. Enable or disable management of the SSSD service.
 * `required_packages`: Hash. A hash of package resources to manage for any auxilliary functionality.
 * `domain`: String. The name of the domain to join.
 * `domain_join_user`: String. The account to be used in joining the domain.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,6 +14,7 @@ realmd::sssd_config_file: /etc/sssd/sssd.conf
 realmd::sssd_config: {}
 realmd::sssd_config_cache_file: /var/lib/sss/db/config.ldb
 realmd::manage_sssd_config: false
+realmd::manage_sssd_service: true
 realmd::domain: "%{::domain}"
 realmd::domain_join_user: ~
 realmd::domain_join_password: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class realmd (
   Stdlib::Absolutepath $sssd_config_cache_file,
   Hash $sssd_config,
   Boolean $manage_sssd_config,
+  Boolean $manage_sssd_service,
   String $domain,
   String $netbiosname,
   Variant[String, Undef] $domain_join_user,

--- a/manifests/sssd/service.pp
+++ b/manifests/sssd/service.pp
@@ -5,13 +5,16 @@
 #
 class realmd::sssd::service {
 
-  $_sssd_service_name = $::realmd::sssd_service_name
+  if $realmd::manage_sssd_service {
+    $_sssd_service_name = $::realmd::sssd_service_name
 
-  service { $_sssd_service_name:
-    ensure     => running,
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
+    service { $_sssd_service_name:
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+    }
   }
+
 
 }


### PR DESCRIPTION
By setting *realmd::manage_sssd_service* to *false* it will now be possible to leave that service untouched by this module.
The default stays unchanged: realmd module will control the sssd service.