### PR TITLE
Fix duplicate definition error, when managing sssd service elsewhere.

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,6 +14,7 @@ realmd::sssd_config_file: /etc/sssd/sssd.conf
 realmd::sssd_config: {}
 realmd::sssd_config_cache_file: /var/lib/sss/db/config.ldb
 realmd::manage_sssd_config: false
+realmd::manage_sssd_service: true
 realmd::domain: "%{::domain}"
 realmd::domain_join_user: ~
 realmd::domain_join_password: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class realmd (
   Stdlib::Absolutepath $sssd_config_cache_file,
   Hash $sssd_config,
   Boolean $manage_sssd_config,
+  Boolean $manage_sssd_service,
   String $domain,
   String $netbiosname,
   Variant[String, Undef] $domain_join_user,
@@ -64,10 +65,17 @@ class realmd (
     fail('The krb_config parameter cannot be an empty hash when managing the Kerberos client configuration')
   }
 
-  class { '::realmd::install': }
-  -> class { '::realmd::config': }
-  ~> class { '::realmd::join': }
-  -> class { '::realmd::sssd::config': }
-  ~> class { '::realmd::sssd::service': }
+  if $manage_sssd_service {
+    class { '::realmd::install': }
+    -> class { '::realmd::config': }
+    ~> class { '::realmd::join': }
+    -> class { '::realmd::sssd::config': }
+    ~> class { '::realmd::sssd::service': }
+  } else {
+    class { '::realmd::install': }
+    -> class { '::realmd::config': }
+    ~> class { '::realmd::join': }
+    -> class { '::realmd::sssd::config': }
+  }
 
 }


### PR DESCRIPTION
When managing sssd with another module, an error "Service['sssd'] already defined. Duplicate declaration.". A well-known error indeed. This fixes that.