### PR TITLE
Fix metadata for 2020

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "walkamongus-realmd",
-  "version": "2.4.0",
+  "version": "2.4.1pre1",
   "author": "Chadwick Banning",
   "summary": "Puppet module to install and configure Realmd",
   "data_provider": "hiera",

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">=3.2.0 <5.0.0"
+      "version_requirement": ">=3.2.0 <7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -32,7 +32,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 6.0.0"
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
Hey, @walkamongus -- from my limited testing on CentOS 7 with Active Directory, this module appears to work out of the box once the metadata.json has been updated to allow current versions of puppet and stdlib. Any chance you could update the official module? Adjust version numbers, squash/rebase, or whatever else you think is needed. Thanks.