### PR TITLE
Add support for EL8, Puppet 7, fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,46 @@ before_install:
   - rm Gemfile.lock || true
   - gem update bundler
 rvm:
-  - 2.1.0
-  - 2.4.0
+  - 2.1.9
+  - 2.4.4
+  - 2.5.6
+  - 2.7.6
 script: bundle exec rake test
 env:
-  - PUPPET_GEM_VERSION="~> 4.10.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 5.0.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 5.1.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 5.2.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 5.3.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 5.5.0" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 5.5" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
 matrix:
   exclude:
+    # PE2021.6
+    - rvm: 2.1.9
+      env: PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
+    - rvm: 2.4.4
+      env: PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
+    - rvm: 2.5.6
+      env: PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
+
+    # PE2019.8
+    - rvm: 2.1.9
+      env: PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
+    - rvm: 2.4.4
+      env: PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
+    - rvm: 2.7.6
+      env: PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
+
+    # PE2018.1
+    - rvm: 2.1.9
+      env: PUPPET_GEM_VERSION="~> 5.5" STRICT_VARIABLES=yes
+    - rvm: 2.5.6
+      env: PUPPET_GEM_VERSION="~> 5.5" STRICT_VARIABLES=yes
+    - rvm: 2.7.6
+      env: PUPPET_GEM_VERSION="~> 5.5" STRICT_VARIABLES=yes
+
+    # PE2016.40
+    - rvm: 2.4.4
+      env: PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes
+    - rvm: 2.5.6
+      env: PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes
+    - rvm: 2.7.6
+      env: PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,50 +6,30 @@ before_install:
   - rm Gemfile.lock || true
   - gem update bundler
 rvm:
-  - 2.1.9
   - 2.4.4
   - 2.5.6
   - 2.7.6
 script: bundle exec rake test
 env:
-  - PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 5.5" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
 matrix:
-  allow_failures:
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes
-
   exclude:
     # PE2021.6
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
     - rvm: 2.4.4
       env: PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
     - rvm: 2.5.6
       env: PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
 
     # PE2019.8
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
     - rvm: 2.4.4
       env: PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
     - rvm: 2.7.6
       env: PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
 
     # PE2018.1
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 5.5" STRICT_VARIABLES=yes
     - rvm: 2.5.6
       env: PUPPET_GEM_VERSION="~> 5.5" STRICT_VARIABLES=yes
     - rvm: 2.7.6
       env: PUPPET_GEM_VERSION="~> 5.5" STRICT_VARIABLES=yes
-
-    # PE2016.40
-    - rvm: 2.4.4
-      env: PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes
-    - rvm: 2.5.6
-      env: PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes
-    - rvm: 2.7.6
-      env: PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+cache: bundler
 bundler_args: --without development
 before_install:
   - rm Gemfile.lock || true
@@ -16,6 +17,10 @@ env:
   - PUPPET_GEM_VERSION="~> 6.27" STRICT_VARIABLES=yes
   - PUPPET_GEM_VERSION="~> 7.16" STRICT_VARIABLES=yes
 matrix:
+  allow_failures:
+    - rvm: 2.1.9
+      env: PUPPET_GEM_VERSION="~> 4.10" STRICT_VARIABLES=yes
+
   exclude:
     # PE2021.6
     - rvm: 2.1.9

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-puppetversion = ENV['PUPPET_VERSION'].nil? ? '>= 6.18' : ENV['PUPPET_VERSION'].to_s
+puppetversion = ENV['PUPPET_GEM_VERSION'] || '>= 6.18'
 puppetver = Gem::Version.new(%r/([\d.]+)/.match(puppetversion)[1])
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-puppetversion = ENV['PUPPET_VERSION'].nil? ? '~> 4.10' : ENV['PUPPET_VERSION'].to_s
+puppetversion = ENV['PUPPET_VERSION'].nil? ? '>= 6.18' : ENV['PUPPET_VERSION'].to_s
 puppetver = Gem::Version.new(%r/([\d.]+)/.match(puppetversion)[1])
 
 group :test do
-  gem "rake"
-  gem "puppet", puppetversion
-  gem "rspec", '~> 3.8.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem "puppetlabs_spec_helper", '~> 2.1'
-  gem "metadata-json-lint"
-  gem "rspec-puppet-facts"
+  gem 'rake'
+  gem 'puppet', puppetversion
+  gem 'rspec', '~> 3.8.0'
+  gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'puppetlabs_spec_helper', '~> 2.1'
+  gem 'metadata-json-lint'
+  gem 'rspec-puppet-facts'
   gem 'rubocop', '0.57.2'
   gem 'semantic_puppet' unless puppetver >= Gem::Version.new('5.0')
   gem 'simplecov', '>= 0.11.0'
@@ -22,13 +22,17 @@ group :test do
 end
 
 group :development do
-  gem "travis"              if RUBY_VERSION >= '2.1.0'
-  gem "travis-lint"         if RUBY_VERSION >= '2.1.0'
-  gem "guard-rake"          if RUBY_VERSION >= '2.2.5' # per dependency https://rubygems.org/gems/ruby_dep
-  gem "puppet-blacksmith"
+  gem 'travis'              if RUBY_VERSION >= '2.1.0'
+  gem 'travis-lint'         if RUBY_VERSION >= '2.1.0'
+  gem 'guard-rake'          if RUBY_VERSION >= '2.2.5' # per dependency https://rubygems.org/gems/ruby_dep
+  gem 'puppet-blacksmith'
 end
 
 group :system_tests do
-  gem 'beaker'       if RUBY_VERSION >= '2.1.8'
-  gem 'beaker-rspec' if RUBY_VERSION >= '2.1.8'
+  if RUBY_VERSION >= '2.1.8'
+    gem 'beaker'
+    gem 'beaker-vagrant'
+    gem 'beaker-rspec'
+    gem 'beaker-puppet'
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 puppetversion = ENV['PUPPET_GEM_VERSION'] || '>= 6.18'
-puppetver = Gem::Version.new(%r/([\d.]+)/.match(puppetversion)[1])
 
 group :test do
   gem 'rake'
@@ -12,27 +11,24 @@ group :test do
   gem 'metadata-json-lint'
   gem 'rspec-puppet-facts'
   gem 'rubocop', '0.57.2'
-  gem 'semantic_puppet' unless puppetver >= Gem::Version.new('5.0')
   gem 'simplecov', '>= 0.11.0'
   gem 'simplecov-console'
   gem 'puppet-lint', '>= 2.0.0'
   gem 'puppet-syntax', '~> 2.4.0'
-  gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+  gem 'json_pure', '<= 2.0.1'
   gem 'net-telnet', '0.1.1'
 end
 
 group :development do
-  gem 'travis'              if RUBY_VERSION >= '2.1.0'
-  gem 'travis-lint'         if RUBY_VERSION >= '2.1.0'
-  gem 'guard-rake'          if RUBY_VERSION >= '2.2.5' # per dependency https://rubygems.org/gems/ruby_dep
+  gem 'travis'
+  gem 'travis-lint'
+  gem 'guard-rake'
   gem 'puppet-blacksmith'
 end
 
 group :system_tests do
-  if RUBY_VERSION >= '2.1.8'
-    gem 'beaker'
-    gem 'beaker-vagrant'
-    gem 'beaker-rspec'
-    gem 'beaker-puppet'
-  end
+  gem 'beaker'
+  gem 'beaker-vagrant'
+  gem 'beaker-rspec'
+  gem 'beaker-puppet'
 end

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,5 +1,6 @@
 ---
 realmd::krb_client_package_name: krb5-workstation
+
 realmd::required_packages:
   oddjob:
     ensure: present
@@ -7,5 +8,4 @@ realmd::required_packages:
     ensure: present
   samba-common-tools:
     ensure: present
-  sssd:
-     ensure: present
+

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,6 +15,7 @@ realmd::sssd_config: {}
 realmd::sssd_config_cache_file: /var/lib/sss/db/config.ldb
 realmd::manage_sssd_config: false
 realmd::manage_sssd_service: true
+realmd::manage_sssd_package: true
 realmd::domain: "%{::domain}"
 realmd::domain_join_user: ~
 realmd::domain_join_password: ~

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,10 +1,12 @@
 ---
-version: 4
-datadir: data
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
 hierarchy:
   - name: "Operating System Family"
-    backend: yaml
-    path: "%{facts.os.family}"
+    path: "%{facts.os.family}.yaml"
 
   - name: "common"
-    backend: yaml
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,17 +66,19 @@ class realmd (
     fail('The krb_config parameter cannot be an empty hash when managing the Kerberos client configuration')
   }
 
+  contain 'realmd::install'
+  contain 'realmd::config'
+  contain 'realmd::join'
+  contain 'realmd::sssd::config'
+
+  Class['realmd::install']
+  -> Class['realmd::config']
+  ~> Class['realmd::join']
+  -> Class['realmd::sssd::config']
+
   if $manage_sssd_service {
-    class { '::realmd::install': }
-    -> class { '::realmd::config': }
-    ~> class { '::realmd::join': }
-    -> class { '::realmd::sssd::config': }
-    ~> class { '::realmd::sssd::service': }
-  } else {
-    class { '::realmd::install': }
-    -> class { '::realmd::config': }
-    ~> class { '::realmd::join': }
-    -> class { '::realmd::sssd::config': }
+    contain 'realmd::sssd::service'
+    Class['realmd::sssd::config'] ~> Class['realmd::sssd::service']
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@ class realmd (
   Hash $sssd_config,
   Boolean $manage_sssd_config,
   Boolean $manage_sssd_service,
+  Boolean $manage_sssd_package,
   String $domain,
   String $netbiosname,
   Variant[String, Undef] $domain_join_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class realmd (
   Variant[String, Undef] $ou,
   Hash $required_packages,
   Variant[Array, Undef] $extra_join_options,
-  Variant[String[1, 15], Undef] $computer_name,
+  Variant[String[1, 15], Undef, Boolean[false]] $computer_name,
 ) {
 
   if $krb_ticket_join == false {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,61 +4,50 @@
 #
 class realmd::install {
 
+  package { $::realmd::realmd_package_name:
+    ensure => $::realmd::realmd_package_ensure,
+  }
+
+  package { $::realmd::adcli_package_name:
+    ensure => $::realmd::adcli_package_ensure,
+  }
+
+  package { $::realmd::krb_client_package_name:
+    ensure => $::realmd::krb_client_package_ensure,
+  }
+
+  if $realmd::manage_sssd_package {
+    package { $::realmd::sssd_package_name:
+      ensure => $::realmd::sssd_package_ensure,
+    }
+  }
+
   case $facts['os']['name'] {
     'Ubuntu': {
       include apt
 
-      package { $::realmd::realmd_package_name:
-        ensure  => $::realmd::realmd_package_ensure,
-        require => Exec['apt_update'],
-      }
-
-      package { $::realmd::adcli_package_name:
-        ensure  => $::realmd::adcli_package_ensure,
-        require => Exec['apt_update'],
-      }
-
-      package { $::realmd::krb_client_package_name:
-        ensure  => $::realmd::krb_client_package_ensure,
-        require => Exec['apt_update'],
-      }
+      Exec['apt_update']
+      -> Package[[
+        $::realmd::realmd_package_name,
+        $::realmd::adcli_package_name,
+        $::realmd::adcli_package_name,
+        $::realmd::krb_client_package_name,
+      ]]
 
       if $realmd::manage_sssd_package {
-        package { $::realmd::sssd_package_name:
-          ensure  => $::realmd::sssd_package_ensure,
-          require => Exec['apt_update'],
-        }
+        Exec['apt_update'] -> Package[$::realmd::sssd_package_name]
       }
 
       $::realmd::required_packages.each | String $package, Hash $content | {
-        package { $package:
+        Exec['apt_update']
+        -> package { $package:
           ensure  => $content['ensure'],
-          require => Exec['apt_update'],
         }
       }
-
     }
     default: {
-      package { $::realmd::realmd_package_name:
-        ensure => $::realmd::realmd_package_ensure,
-      }
-
-      package { $::realmd::adcli_package_name:
-        ensure => $::realmd::adcli_package_ensure,
-      }
-
-      package { $::realmd::krb_client_package_name:
-        ensure => $::realmd::krb_client_package_ensure,
-      }
-
-      package { $::realmd::sssd_package_name:
-        ensure => $::realmd::sssd_package_ensure,
-      }
-
       ensure_packages($::realmd::required_packages)
     }
   }
-
-
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,9 +23,11 @@ class realmd::install {
         require => Exec['apt_update'],
       }
 
-      package { $::realmd::sssd_package_name:
-        ensure  => $::realmd::sssd_package_ensure,
-        require => Exec['apt_update'],
+      if $realmd::manage_sssd_package {
+        package { $::realmd::sssd_package_name:
+          ensure  => $::realmd::sssd_package_ensure,
+          require => Exec['apt_update'],
+        }
       }
 
       $::realmd::required_packages.each | String $package, Hash $content | {

--- a/manifests/join/password.pp
+++ b/manifests/join/password.pp
@@ -24,8 +24,11 @@ class realmd::join::password {
       'focal'   => '',
       'default' => ["--computer-name=${_computer_name}"],
     }
-  } else {
-      $_computer_name_arg = ["--computer-name=${_computer_name}"]
+  } elsif ($facts['os']['family'] == 'RedHat' and Integer($facts['os']['release']['major']) >= 8)  {
+    $_computer_name_arg = ''
+  }
+  else {
+    $_computer_name_arg = ["--computer-name=${_computer_name}"]
   }
 
   if $_ou != undef {

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,6 @@
   "version": "2.5.0",
   "author": "Chadwick Banning",
   "summary": "Puppet module to install and configure Realmd",
-  "data_provider": "hiera",
   "license": "Apache-2.0",
   "source": "https://github.com/walkamongus/realmd",
   "project_page": "https://github.com/walkamongus/realmd",

--- a/metadata.json
+++ b/metadata.json
@@ -47,6 +47,13 @@
       ]
     },
     {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "20.04"

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,21 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
       ]
     },
     {
@@ -42,7 +56,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 4.0.0 < 8.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "walkamongus-realmd",
-  "version": "2.4.1pre1",
+  "version": "2.5.0",
   "author": "Chadwick Banning",
   "summary": "Puppet module to install and configure Realmd",
   "data_provider": "hiera",

--- a/metadata.json
+++ b/metadata.json
@@ -63,7 +63,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 8.0.0"
+      "version_requirement": ">= 5.0.0 < 8.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/rockylinux-8-x64.yml
+++ b/spec/acceptance/nodesets/rockylinux-8-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  rockylinux-8-x64:
+    roles:
+      - master
+    platform: el-8-x86_64
+    box: generic/rocky8
+    box_url: https://app.vagrantup.com/generic/boxes/rocky8
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss
+  synced_folder: disabled

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,7 +20,15 @@ describe 'realmd' do
           it { is_expected.to contain_class('realmd::sssd::config').that_requires('Class[realmd::join]') }
           it { is_expected.to contain_class('realmd::sssd::service').that_subscribes_to('Class[realmd::sssd::config]') }
         end
+
+        context "realmd class with manage_sssd_package => false" do
+          let(:params) { { 'manage_sssd_package' => false } }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_package('sssd') }
+        end
       end
+
+
     end
   end
 

--- a/spec/classes/join__password_spec.rb
+++ b/spec/classes/join__password_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe 'realmd' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) do
-          facts
+          os_facts
         end
 
         context "realmd::join::password class" do
@@ -17,18 +17,35 @@ describe 'realmd' do
             }
           end
 
+          let(:doesnt_use_computer_name) do
+            is_ubuntu_20 = (
+              facts.dig(:os,'distro','id') == 'Ubuntu' &&
+              %w[xenial bionic focal].include?(facts.dig(:os,'distro','codename'))
+            )
+            is_el8_or_higher = (
+              facts.dig(:os,'family') == 'RedHat' &&
+              facts.dig(:os,'release','major').to_i >= 8
+            )
+            is_ubuntu_20 || is_el8_or_higher
+          end
           it { is_expected.to contain_class('realmd::join::password') }
 
           it do
             command = '/usr/libexec/realm_join_with_password realm join example.com --unattended --user=user'
-            unless facts.dig(:os,'distro','id') == 'Ubuntu' && %w[xenial bionic focal].include?(facts.dig(:os,'distro','codename'))
-               command += ' --computer-name=foo'
+            if doesnt_use_computer_name
+              is_expected.to contain_exec('realm_join_with_password').with({
+                'path'    => '/usr/bin:/usr/sbin:/bin',
+                'command' => command,
+                'unless'  => "klist -k /etc/krb5.keytab | grep -i 'foo@example.com'",
+              })
+            else
+              is_expected.to contain_exec('realm_join_with_password').with({
+                'path'    => '/usr/bin:/usr/sbin:/bin',
+                'command' => command += ' --computer-name=foo',
+                'unless'  => "klist -k /etc/krb5.keytab | grep -i 'foo@example.com'",
+              })
             end
-            is_expected.to contain_exec('realm_join_with_password').with({
-              'path'    => '/usr/bin:/usr/sbin:/bin',
-              'command' => command,
-              'unless'  => "klist -k /etc/krb5.keytab | grep -i 'foo@example.com'",
-            })
+
           end
         end
       end

--- a/spec/classes/join__password_spec.rb
+++ b/spec/classes/join__password_spec.rb
@@ -20,9 +20,13 @@ describe 'realmd' do
           it { is_expected.to contain_class('realmd::join::password') }
 
           it do
+            command = '/usr/libexec/realm_join_with_password realm join example.com --unattended --user=user'
+            unless facts.dig(:os,'distro','id') == 'Ubuntu' && %w[xenial bionic focal].include?(facts.dig(:os,'distro','codename'))
+               command += ' --computer-name=foo'
+            end
             is_expected.to contain_exec('realm_join_with_password').with({
               'path'    => '/usr/bin:/usr/sbin:/bin',
-              'command' => '/usr/libexec/realm_join_with_password realm join example.com --unattended --user=user --computer-name=foo',
+              'command' => command,
               'unless'  => "klist -k /etc/krb5.keytab | grep -i 'foo@example.com'",
             })
           end


### PR DESCRIPTION
This patch adds support for Rocky Linux 8 and makes sssd package management optional.  In the process, it fixes some other things:

* Adds support for EL8 (RedHat, CentOS, Rocky, OracleLinux)
* Adds boolean parameter `realmd::manage_sssd_package`
  * Adds spec test to test the new parameter
* Updates the Gemfile to use modern versions of Puppet & Beaker
* Updates spec_acceptance_helpers to use modern gems
* Adds a Beaker nodeset for Rocky Linux 8 acceptance tests
* Fixes spec expectations that failed on Ubuntu 20 factset 
* Contains sub classes in init.pp (Fixes #71)
* Updates Travis matrix to test PE AIO versions
* Bump module SemVer to 2.5.0 (`pre1` was causing test failures)
* Upgraded module to Hiera 5
* Added support for Puppet 7, removed support for Puppet 4

Closes #79, Closes #80